### PR TITLE
Removed hibernate dom4j workarounds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,14 +8,8 @@ scalaVersion := "2.11.8"
 
 libraryDependencies += javaJpa
 
-// https://mvnrepository.com/artifact/dom4j/dom4j
-libraryDependencies += "dom4j" % "dom4j" % "1.6"
-
 libraryDependencies += "org.mockito" % "mockito-core" % "2.1.0"
 
 libraryDependencies += javaWs % "test"
 
-// https://mvnrepository.com/artifact/org.hibernate/hibernate-core
-// must exclude dom4j in hibernate core because it causes staxeventreader exceptions
-// http://stackoverflow.com/questions/36222306/caused-by-java-lang-classnotfoundexception-org-dom4j-io-staxeventreader
-libraryDependencies += "org.hibernate" % "hibernate-core" % "5.2.3.Final" exclude("dom4j", "dom4j") exclude("javax.transaction", "jta") exclude("org.slf4j", "slf4j-api")
+libraryDependencies += "org.hibernate" % "hibernate-core" % "5.2.5.Final"


### PR DESCRIPTION
This was actually [a bug in sbt](https://github.com/sbt/sbt/issues/1431) which was fixed in `0.13.13`.
Also see [my answer on stackoverflow](http://stackoverflow.com/a/38284978/810109)

I did test this `play-java-intro` and can confirm this is working without these hacks now.